### PR TITLE
fix: improve light mode border visibility on edit DPM page

### DIFF
--- a/src/app/dpms/edit-dpms/edit-dpms.component.css
+++ b/src/app/dpms/edit-dpms/edit-dpms.component.css
@@ -387,3 +387,28 @@
     background-color: var(--color-error-900) !important;
   }
 }
+
+/* ============================================
+   Light Mode Border Visibility
+   ============================================ */
+
+/* Slightly darker borders for better visibility in light mode */
+:host-context([data-theme='light']) .dpm-list {
+  border-color: oklch(0.88 0 0);
+}
+
+:host-context([data-theme='light']) .dpm-type-box {
+  border-bottom-color: oklch(0.88 0 0);
+}
+
+:host-context([data-theme='light']) .dpm-header-row {
+  border-bottom-color: oklch(0.88 0 0);
+}
+
+:host-context([data-theme='light']) .sticky-save-bar {
+  border-top-color: oklch(0.88 0 0);
+}
+
+:host-context([data-theme='light']) .group-card {
+  border-color: oklch(0.91 0 0);
+}


### PR DESCRIPTION
## Summary
- Adds light-mode-only CSS overrides to improve border visibility on the edit DPM page
- Row separators, header row, and save bar use `oklch(0.88 0 0)` for better definition
- Group card borders use `oklch(0.91 0 0)` for a more subtle appearance
- Dark mode remains completely unchanged

## Test plan
- [ ] View edit DPM page in light mode - borders should be visible but not harsh
- [ ] View edit DPM page in dark mode - should look identical to before
- [ ] Verify row separators are slightly more prominent than group borders

🤖 Generated with [Claude Code](https://claude.com/claude-code)