### PR TITLE
fix: correct DPM pluralization on autogen submit button

### DIFF
--- a/src/app/dpms/autogen/autogen.component.html
+++ b/src/app/dpms/autogen/autogen.component.html
@@ -118,7 +118,7 @@
             } @else {
               <app-button variant="primary" size="lg" [disabled]="empty()" (click)="onSubmit()">
                 <i class="pi pi-send mr-2"></i>
-                Submit {{ autogenDpms().length }} DPMs
+                Submit {{ autogenDpms().length }} {{ autogenDpms().length === 1 ? 'DPM' : 'DPMs' }}
               </app-button>
             }
           </div>
@@ -226,7 +226,7 @@
             } @else {
               <app-button variant="primary" size="lg" [disabled]="empty()" (click)="onSubmit()">
                 <i class="pi pi-send mr-2"></i>
-                Submit {{ autogenDpms().length }} DPMs
+                Submit {{ autogenDpms().length }} {{ autogenDpms().length === 1 ? 'DPM' : 'DPMs' }}
               </app-button>
             }
           </div>


### PR DESCRIPTION
## Summary
- Fixes grammatical issue where button displayed "Submit 1 DPMs" instead of "Submit 1 DPM"
- Adds conditional pluralization for both mobile and desktop submit buttons

## Test plan
- [ ] Navigate to the autogen page with exactly 1 DPM and verify button says "Submit 1 DPM"
- [ ] Verify with multiple DPMs the button says "Submit X DPMs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)