### PR TITLE
feat: add 250 character limit to DPM notes input

### DIFF
--- a/src/app/dpms/new-dpm/new-dpm.component.html
+++ b/src/app/dpms/new-dpm/new-dpm.component.html
@@ -188,6 +188,7 @@
           placeholder="Abducted by Aliens"
           class="w-full px-4 py-2.5 rounded-lg dpm-form-input text-base-content placeholder:text-neutral-400 shadow-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500"
           autocomplete="off"
+          maxlength="250"
           formControlName="notes"
         />
       </div>


### PR DESCRIPTION
## Summary
- Adds `maxlength="250"` to the notes input on the new DPM form
- Prevents excessively long notes entries

## Test plan
- [ ] Navigate to the new DPM form
- [ ] Verify the notes input stops accepting characters after 250

🤖 Generated with [Claude Code](https://claude.com/claude-code)