### PR TITLE
fix: post-deployment mobile UI improvements

### DIFF
--- a/src/app/dpms/autogen/autogen.component.html
+++ b/src/app/dpms/autogen/autogen.component.html
@@ -15,22 +15,19 @@
         <div
           class="sm:hidden flex items-center justify-center gap-6 py-3 px-4 mb-4 bg-base-100 rounded-xl border border-neutral-200 dark:border-neutral-700"
         >
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-1.5">
             <i class="pi pi-list text-primary-500"></i>
             <span class="font-semibold text-base-content">{{ autogenDpms().length }}</span>
-            <span class="text-xs text-base-content/60">Total</span>
           </div>
           <div class="w-px h-6 bg-neutral-200 dark:bg-neutral-700"></div>
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-1.5">
             <i class="pi pi-plus-circle text-success-500"></i>
             <span class="font-semibold text-success-600">{{ getPositiveCount() }}</span>
-            <span class="text-xs text-base-content/60">Positive</span>
           </div>
           <div class="w-px h-6 bg-neutral-200 dark:bg-neutral-700"></div>
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-1.5">
             <i class="pi pi-minus-circle text-error-500"></i>
             <span class="font-semibold text-error-600">{{ getNegativeCount() }}</span>
-            <span class="text-xs text-base-content/60">Negative</span>
           </div>
         </div>
 

--- a/src/app/dpms/dpm-page/dpm-page.component.html
+++ b/src/app/dpms/dpm-page/dpm-page.component.html
@@ -25,7 +25,7 @@
       <button
         role="tab"
         type="button"
-        class="px-5 py-2.5 font-medium text-sm rounded-lg transition-all duration-200 cursor-pointer"
+        class="hidden sm:block px-5 py-2.5 font-medium text-sm rounded-lg transition-all duration-200 cursor-pointer"
         [ngClass]="{
           'bg-primary-600 text-white shadow-sm': active.edit,
           'bg-transparent text-base-content/60 hover:text-base-content hover:bg-base-300/50':

--- a/src/app/dpms/edit-dpms/edit-dpms.component.css
+++ b/src/app/dpms/edit-dpms/edit-dpms.component.css
@@ -100,7 +100,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  display: flex;
+  display: none;
   justify-content: center;
   align-items: center;
   /* Fixed height for consistent sizing */
@@ -111,6 +111,13 @@
   z-index: 10;
   /* For absolute positioning of error indicator */
   isolation: isolate;
+}
+
+/* Show save bar only on tablet and up */
+@media (min-width: 640px) {
+  .sticky-save-bar {
+    display: flex;
+  }
 }
 
 /* Column header row */

--- a/src/app/dpms/edit-dpms/edit-dpms.component.html
+++ b/src/app/dpms/edit-dpms/edit-dpms.component.html
@@ -1,6 +1,22 @@
 <div>
+  <!-- Mobile: Show message to use desktop -->
+  <div
+    class="sm:hidden flex flex-col items-center justify-center py-12 px-6 bg-base-100 rounded-2xl border border-neutral-200 dark:border-neutral-700"
+  >
+    <div
+      class="w-16 h-16 rounded-full bg-gradient-to-br from-neutral-100 to-neutral-200 dark:from-neutral-800 dark:to-neutral-700 flex items-center justify-center mb-4 shadow-inner"
+    >
+      <i class="pi pi-desktop text-2xl text-neutral-400"></i>
+    </div>
+    <h3 class="text-lg font-semibold text-base-content mb-2">Desktop Required</h3>
+    <p class="text-sm text-base-content/60 text-center">
+      The DPM type editor requires a larger screen. Please use a tablet or desktop device.
+    </p>
+  </div>
+
+  <!-- Desktop: Show the editor -->
   @if (dpmEditForm) {
-    <div class="flex justify-end gap-2 mb-4">
+    <div class="hidden sm:flex justify-end gap-2 mb-4">
       <app-button
         variant="primary"
         size="sm"
@@ -25,7 +41,7 @@
   }
 
   @if (dpmEditForm) {
-    <form [formGroup]="dpmEditForm" cdkDropListGroup>
+    <form [formGroup]="dpmEditForm" cdkDropListGroup class="hidden sm:block">
       <div
         cdkDropList
         formArrayName="groups"
@@ -245,7 +261,7 @@
       </div>
     </form>
 
-    <div class="sticky-save-bar">
+    <div class="sticky-save-bar hidden sm:flex">
       @if (formHasErrors() && getTotalErrorCount() > 0) {
         <button
           type="button"

--- a/src/app/dpms/new-dpm/new-dpm.component.html
+++ b/src/app/dpms/new-dpm/new-dpm.component.html
@@ -176,6 +176,7 @@
             </optgroup>
           }
         </select>
+        <div class="min-h-5"></div>
       </div>
 
       <div class="flex flex-col gap-1.5">
@@ -191,6 +192,7 @@
           maxlength="250"
           formControlName="notes"
         />
+        <div class="min-h-5"></div>
       </div>
     </div>
 

--- a/src/app/ui/page-header/page-header.component.html
+++ b/src/app/ui/page-header/page-header.component.html
@@ -1,11 +1,11 @@
-<div class="flex items-center gap-3 mb-6">
-  <div [class]="iconClasses()">
+<div class="flex items-center gap-3 mb-6 overflow-hidden">
+  <div [class]="iconClasses()" class="shrink-0">
     <i [class]="'pi ' + icon() + ' text-lg text-white'"></i>
   </div>
-  <div>
-    <h2 class="text-2xl font-bold text-base-content">{{ title() }}</h2>
+  <div class="min-w-0 overflow-hidden">
+    <h2 class="text-2xl font-bold text-base-content truncate">{{ title() }}</h2>
     @if (subtitle()) {
-      <p class="text-sm text-base-content/60">
+      <p class="text-sm text-base-content/60 break-words">
         {{ subtitle() }}
       </p>
     }

--- a/src/app/users/user-form/user-form.component.html
+++ b/src/app/users/user-form/user-form.component.html
@@ -103,6 +103,7 @@
           <option [value]="manager">{{ manager }}</option>
         }
       </select>
+      <div class="min-h-5"></div>
     </div>
 
     <div class="flex flex-col gap-1.5">
@@ -122,20 +123,24 @@
           }
         </select>
       </div>
+      <div class="min-h-5"></div>
     </div>
   </div>
 
   <!-- Row 3: Full Time Checkbox -->
-  <div class="flex items-center gap-3">
-    <input
-      id="fullTimeCheckBox"
-      type="checkbox"
-      class="form-checkbox form-checkbox-primary rounded"
-      formControlName="fullTime"
-    />
-    <label for="fullTimeCheckBox" class="text-base-content font-medium text-sm cursor-pointer">
-      Full Time Employee
-    </label>
+  <div class="flex flex-col gap-1.5">
+    <div class="flex items-center gap-3">
+      <input
+        id="fullTimeCheckBox"
+        type="checkbox"
+        class="form-checkbox form-checkbox-primary rounded"
+        formControlName="fullTime"
+      />
+      <label for="fullTimeCheckBox" class="text-base-content font-medium text-sm cursor-pointer">
+        Full Time Employee
+      </label>
+    </div>
+    <div class="min-h-5"></div>
   </div>
 
   <!-- Form Actions -->

--- a/src/styles.css
+++ b/src/styles.css
@@ -1693,6 +1693,7 @@ nav a.bg-white {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.025em;
+  white-space: nowrap;
 }
 
 .autogen-badge-success {


### PR DESCRIPTION
## Summary
- **Form spacing**: Add consistent spacing to form fields missing validation message containers (new DPM form, user form)
- **Autogen stats**: Simplify mobile stats bar to icons + numbers only (removes text labels that caused overflow)
- **Autogen badges**: Prevent status badges from wrapping ("PICKED UP" stays on one line)
- **Page header**: Fix text overflow on small screens with proper truncation and word-break
- **Edit DPMs**: Hide editor on mobile with friendly "Desktop Required" message
- **Edit DPMs**: Hide Edit tab and save bar on mobile (editor requires larger screen)

## Test plan
- [ ] New DPM form: verify consistent spacing between all fields on mobile
- [ ] User form: verify consistent spacing between all fields on mobile
- [ ] Autogen page: verify stats bar shows only icons + numbers on mobile
- [ ] Autogen page: verify status badges stay on one line
- [ ] Autogen page: verify header text doesn't overflow
- [ ] DPM Management: verify Edit tab is hidden on mobile
- [ ] DPM Management: verify "Desktop Required" message shows on mobile when on edit view
- [ ] DPM Management: verify Edit tab and editor work normally on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)