### PR TITLE
Use neutral loading skeleton on home page

### DIFF
--- a/src/app/dpms/home/home.component.html
+++ b/src/app/dpms/home/home.component.html
@@ -1,41 +1,26 @@
 @if (isLoading()) {
   <div class="px-4 py-6 md:px-6 md:py-8">
     <div class="max-w-5xl mx-auto space-y-6">
-      <!-- Hero Section Skeleton -->
-      <section class="bg-gradient-to-br from-primary-600 to-primary-700 rounded-2xl p-6 md:p-8">
-        <div class="flex items-center gap-4 mb-6">
-          <app-skeleton width="w-12" height="h-12" rounded="lg" class="bg-white/20" />
-          <div class="space-y-2">
-            <app-skeleton width="w-48" height="h-6" class="bg-white/20" />
-            <app-skeleton width="w-32" height="h-4" class="bg-white/20" />
-          </div>
+      <!-- Page Header Skeleton -->
+      <div class="flex items-center gap-3 mb-6">
+        <app-skeleton width="w-10" height="h-10" rounded="lg" />
+        <div class="space-y-2">
+          <app-skeleton width="w-36" height="h-6" />
+          <app-skeleton width="w-48" height="h-4" />
         </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          @for (i of [0, 1, 2]; track i) {
-            <div class="bg-white/10 rounded-xl p-4">
-              <app-skeleton width="w-20" height="h-3" class="bg-white/20 mb-2" />
-              <app-skeleton width="w-12" height="h-8" class="bg-white/20" />
-            </div>
-          }
-        </div>
-      </section>
-
-      <!-- Mobile Card Skeleton -->
-      <div class="md:hidden">
-        <app-card-skeleton [count]="5" />
       </div>
 
-      <!-- Desktop Table Skeleton -->
-      <div
-        class="hidden md:block bg-base-100 rounded-2xl border border-neutral-200 dark:border-neutral-700 shadow-lg overflow-hidden"
-      >
-        <app-table-skeleton [rows]="5" [columns]="3" />
+      <!-- Content Placeholder -->
+      <div class="flex flex-col items-center justify-center py-16 px-6">
+        <app-skeleton width="w-16" height="h-16" rounded="full" class="mb-4" />
+        <app-skeleton width="w-32" height="h-5" class="mb-2" />
+        <app-skeleton width="w-56" height="h-4" />
       </div>
     </div>
   </div>
 } @else {
   @let dpms = currentDpms();
-  <div class="px-4 py-6 md:px-6 md:py-8">
+  <div class="px-4 py-6 md:px-6 md:py-8 home-fade-in">
     <div class="max-w-5xl mx-auto space-y-6">
       @if (dpms.length === 0) {
         <app-page-header

--- a/src/app/dpms/home/home.component.ts
+++ b/src/app/dpms/home/home.component.ts
@@ -10,11 +10,7 @@ import { TableColumn } from '../../ui/data-table/data-table.types';
 import HomeDpmDto from '../../models/home-dpm-dto';
 import { EmptyStateComponent } from '../../ui/empty-state/empty-state.component';
 import { PageHeaderComponent } from '../../ui/page-header/page-header.component';
-import {
-  SkeletonComponent,
-  TableSkeletonComponent,
-  CardSkeletonComponent,
-} from '../../ui/skeleton';
+import { SkeletonComponent } from '../../ui/skeleton';
 
 @Component({
   selector: 'app-home',
@@ -29,8 +25,6 @@ import {
     EmptyStateComponent,
     PageHeaderComponent,
     SkeletonComponent,
-    TableSkeletonComponent,
-    CardSkeletonComponent,
   ],
 })
 export class HomeComponent {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2455,6 +2455,21 @@ nav a.bg-white {
   transition: all 0.15s ease;
 }
 
+.home-fade-in {
+  animation: homeFadeIn 0.4s ease-out;
+}
+
+@keyframes homeFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .home-row-new {
   animation: fadeInRow 0.45s ease-out backwards;
 }


### PR DESCRIPTION
## Summary
- Replace the data-heavy skeleton (gradient hero + stat cards + table rows) with a neutral placeholder that mirrors the page header + centered content layout
- Add a fade-in animation when content resolves, smoothing the skeleton-to-content transition
- Prevents the jarring flash when the page loads and resolves to the "No DPMs Yet" empty state

## Test plan
- [ ] Login with a user that has no DPMs — verify smooth transition from neutral skeleton to empty state
- [ ] Login with a user that has DPMs — verify smooth transition from skeleton to data view
- [ ] Run `npm test -- --no-watch --browsers=ChromeHeadless --include="**/home.component.spec.ts"` — all 24 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)