### PR TITLE
[codex] Frontend API updates for backend audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ firebase-debug.log
 /playwright-report/
 /playwright/.cache/
 /test-results/
+
+# Git worktrees
+/.worktrees/

--- a/src/app/auth/auth.interceptor.fn.ts
+++ b/src/app/auth/auth.interceptor.fn.ts
@@ -7,6 +7,10 @@ import { AuthService } from '../services/auth.service';
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const router = inject(Router);
   const authService = inject(AuthService);
+  const isAuthFlowRequest =
+    req.url.includes('/api/auth/login') ||
+    req.url.includes('/api/auth/changePassword') ||
+    req.url.includes('/api/auth/resetPassword');
 
   if (authService.isAuthenticated()) {
     req = req.clone({
@@ -18,10 +22,7 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
     tap({
       error: (error: unknown) => {
         if (error instanceof HttpErrorResponse) {
-          if (
-            error.status === 401 &&
-            !(req.url.includes('/api/auth/login') || req.url.includes('/api/auth/changePassword'))
-          ) {
+          if (error.status === 401 && !isAuthFlowRequest) {
             console.log('Not authorized, redirecting to login page');
             router.navigate(['/login']);
           } else if (error.status === 303) {

--- a/src/app/auth/auth.routes.ts
+++ b/src/app/auth/auth.routes.ts
@@ -4,6 +4,7 @@ import { LoginComponent } from './login/login.component';
 import { GenerateTitle } from '../shared/title-helper';
 import { authGuard } from './auth.guard';
 import { ChangePasswordComponent } from './change-password/change-password.component';
+import { PasswordResetComponent } from './password-reset/password-reset.component';
 
 export const AUTH_ROUTES: Route[] = [
   {
@@ -33,6 +34,17 @@ export const AUTH_ROUTES: Route[] = [
         data: {
           allowedRoles: ['ADMIN', 'ANALYST', 'DRIVER', 'MANAGER', 'SUPERVISOR'],
         },
+      },
+    ],
+  },
+  {
+    path: 'passwordReset',
+    component: AuthComponent,
+    children: [
+      {
+        path: '',
+        component: PasswordResetComponent,
+        title: GenerateTitle('Reset Password'),
       },
     ],
   },

--- a/src/app/auth/password-reset/password-reset.component.html
+++ b/src/app/auth/password-reset/password-reset.component.html
@@ -1,0 +1,147 @@
+<div
+  class="min-h-screen flex items-center justify-center bg-gradient-to-br from-base-100 to-base-200 px-4"
+>
+  <div class="w-full max-w-md">
+    <div class="text-center mb-8">
+      <div
+        class="w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-to-br from-primary-500 to-primary-600 flex items-center justify-center shadow-lg shadow-primary-500/25"
+      >
+        <i class="pi pi-key text-2xl text-white"></i>
+      </div>
+      <h1 class="text-3xl font-bold text-base-content">Reset Password</h1>
+      <p class="text-sm text-base-content/60 mt-2">Choose a new password for your account</p>
+    </div>
+
+    <div
+      class="bg-base-100 rounded-2xl border border-neutral-200 dark:border-neutral-700 p-8 shadow-xl"
+    >
+      @if (invalidResetLink()) {
+        <div
+          class="rounded-lg bg-error-50 dark:bg-error-900/20 border border-error-200 dark:border-error-800 p-4"
+        >
+          <p class="text-sm text-error-600 dark:text-error-400 font-medium flex items-center gap-2">
+            <i class="pi pi-exclamation-circle"></i>
+            Reset link is invalid or expired.
+          </p>
+        </div>
+      } @else {
+        <form class="space-y-5" [formGroup]="passwordResetFormGroup" (ngSubmit)="onSubmit()">
+          <div class="space-y-2">
+            <label
+              for="newPassword"
+              class="block text-xs font-medium text-primary-600 dark:text-primary-400 uppercase tracking-wide"
+            >
+              New Password
+            </label>
+            <div class="relative">
+              <input
+                id="newPassword"
+                [type]="showNewPassword() ? 'text' : 'password'"
+                class="w-full px-4 py-3 pr-12 rounded-lg bg-base-200 border text-base-content placeholder:text-base-content/40 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-0"
+                [ngClass]="{
+                  'border-neutral-200 dark:border-neutral-700 focus:border-primary-500 focus:ring-primary-500/20 focus:bg-primary-50/50 dark:focus:bg-primary-900/10':
+                    !hasErrors(newPassword) && !getNewPasswordValidationMessages(),
+                  'border-error-500 focus:border-error-500 focus:ring-error-500/20 bg-error-50/50 dark:bg-error-900/10':
+                    hasErrors(newPassword) || getNewPasswordValidationMessages(),
+                }"
+                [attr.aria-describedby]="
+                  getNewPasswordValidationMessages() ? 'newPassword-error' : null
+                "
+                placeholder="Enter new password"
+                formControlName="newPassword"
+              />
+              <button
+                type="button"
+                class="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/40 hover:text-base-content transition-colors cursor-pointer"
+                (click)="showNewPassword.set(!showNewPassword())"
+                aria-label="Toggle new password visibility"
+              >
+                <i [class]="showNewPassword() ? 'pi pi-eye-slash' : 'pi pi-eye'"></i>
+              </button>
+            </div>
+            @if (getNewPasswordValidationMessages()) {
+              <p id="newPassword-error" class="text-sm text-error-600 font-medium mt-1.5">
+                {{ getNewPasswordValidationMessages() }}
+              </p>
+            }
+          </div>
+
+          <div class="space-y-2">
+            <label
+              for="confirmPassword"
+              class="block text-xs font-medium text-primary-600 dark:text-primary-400 uppercase tracking-wide"
+            >
+              Confirm Password
+            </label>
+            <div class="relative">
+              <input
+                id="confirmPassword"
+                [type]="showConfirmPassword() ? 'text' : 'password'"
+                class="w-full px-4 py-3 pr-12 rounded-lg bg-base-200 border text-base-content placeholder:text-base-content/40 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-0"
+                [ngClass]="{
+                  'border-neutral-200 dark:border-neutral-700 focus:border-primary-500 focus:ring-primary-500/20 focus:bg-primary-50/50 dark:focus:bg-primary-900/10':
+                    !hasErrors(confirmPassword) && !getConfirmPasswordValidationMessages(),
+                  'border-error-500 focus:border-error-500 focus:ring-error-500/20 bg-error-50/50 dark:bg-error-900/10':
+                    hasErrors(confirmPassword) || getConfirmPasswordValidationMessages(),
+                }"
+                [attr.aria-describedby]="
+                  getConfirmPasswordValidationMessages() ? 'confirmPassword-error' : null
+                "
+                placeholder="Confirm new password"
+                formControlName="confirmPassword"
+              />
+              <button
+                type="button"
+                class="absolute right-3 top-1/2 -translate-y-1/2 text-base-content/40 hover:text-base-content transition-colors cursor-pointer"
+                (click)="showConfirmPassword.set(!showConfirmPassword())"
+                aria-label="Toggle confirm password visibility"
+              >
+                <i [class]="showConfirmPassword() ? 'pi pi-eye-slash' : 'pi pi-eye'"></i>
+              </button>
+            </div>
+            @if (getConfirmPasswordValidationMessages()) {
+              <p id="confirmPassword-error" class="text-sm text-error-600 font-medium mt-1.5">
+                {{ getConfirmPasswordValidationMessages() }}
+              </p>
+            }
+          </div>
+
+          <button
+            id="submitButton"
+            type="submit"
+            class="w-full mt-6 px-6 py-3.5 bg-gradient-to-r from-primary-600 to-primary-500 text-white font-semibold rounded-lg shadow-lg shadow-primary-500/25 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-base-100 disabled:opacity-40 disabled:cursor-not-allowed disabled:shadow-none hover:from-primary-700 hover:to-primary-600 hover:shadow-xl hover:shadow-primary-500/30 active:scale-[0.98] cursor-pointer"
+            [disabled]="!passwordResetFormGroup.valid || waitingForResponse()"
+          >
+            @if (waitingForResponse()) {
+              <span class="inline-flex items-center gap-2">
+                <svg
+                  class="animate-spin h-5 w-5"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    class="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    stroke-width="4"
+                  ></circle>
+                  <path
+                    class="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  ></path>
+                </svg>
+                Resetting...
+              </span>
+            } @else {
+              Reset Password
+            }
+          </button>
+        </form>
+      }
+    </div>
+  </div>
+</div>

--- a/src/app/auth/password-reset/password-reset.component.spec.ts
+++ b/src/app/auth/password-reset/password-reset.component.spec.ts
@@ -1,0 +1,167 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { PasswordResetComponent } from './password-reset.component';
+import { AuthService } from '../../services/auth.service';
+import { NotificationService } from '../../services/notification.service';
+
+describe('PasswordResetComponent', () => {
+  let component: PasswordResetComponent;
+  let fixture: ComponentFixture<PasswordResetComponent>;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let notificationServiceSpy: jasmine.SpyObj<NotificationService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  async function setup(token: string | null = 'reset-token') {
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['completePasswordReset']);
+    authServiceSpy.completePasswordReset.and.returnValue(of(void 0));
+
+    notificationServiceSpy = jasmine.createSpyObj('NotificationService', [
+      'showSuccess',
+      'showError',
+      'showWarning',
+      'showInfo',
+    ]);
+
+    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
+
+    await TestBed.configureTestingModule({
+      imports: [PasswordResetComponent],
+      providers: [
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: NotificationService, useValue: notificationServiceSpy },
+        { provide: Router, useValue: routerSpy },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParamMap: convertToParamMap(token ? { token } : {}),
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PasswordResetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    spyOn(console, 'error');
+  }
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('should create', async () => {
+    await setup();
+
+    expect(component).toBeTruthy();
+  });
+
+  it('should disable the form when reset token is missing', async () => {
+    await setup(null);
+
+    expect(component.invalidResetLink()).toBe(true);
+    expect(component.passwordResetFormGroup.disabled).toBe(true);
+  });
+
+  it('should be valid when password fields match', async () => {
+    await setup();
+
+    component.passwordResetFormGroup.patchValue({
+      newPassword: 'newpassword123',
+      confirmPassword: 'newpassword123',
+    });
+
+    expect(component.passwordResetFormGroup.valid).toBe(true);
+  });
+
+  it('should show mismatch message when passwords do not match', async () => {
+    await setup();
+
+    component.passwordResetFormGroup.patchValue({
+      newPassword: 'newpassword123',
+      confirmPassword: 'different123',
+    });
+
+    expect(component.getConfirmPasswordValidationMessages()).toBe(
+      'Password does not match new password'
+    );
+  });
+
+  it('should call completePasswordReset with token and form values', async () => {
+    await setup('reset-token-123');
+    component.passwordResetFormGroup.patchValue({
+      newPassword: 'newpassword123',
+      confirmPassword: 'newpassword123',
+    });
+
+    component.onSubmit();
+
+    expect(authServiceSpy.completePasswordReset).toHaveBeenCalledWith({
+      token: 'reset-token-123',
+      newPassword: 'newpassword123',
+      confirmPassword: 'newpassword123',
+    });
+  });
+
+  it('should navigate to login and show success on reset success', async () => {
+    await setup();
+    component.passwordResetFormGroup.patchValue({
+      newPassword: 'newpassword123',
+      confirmPassword: 'newpassword123',
+    });
+
+    component.onSubmit();
+    await fixture.whenStable();
+
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/login']);
+    expect(notificationServiceSpy.showSuccess).toHaveBeenCalledWith('Password has been reset');
+  });
+
+  it('should disable the form for invalid or expired reset token responses', async () => {
+    await setup();
+    const error = new HttpErrorResponse({
+      status: 422,
+      statusText: 'Unprocessable Entity',
+    });
+    authServiceSpy.completePasswordReset.and.returnValue(throwError(() => error));
+    component.passwordResetFormGroup.patchValue({
+      newPassword: 'newpassword123',
+      confirmPassword: 'newpassword123',
+    });
+
+    component.onSubmit();
+
+    expect(component.invalidResetLink()).toBe(true);
+    expect(component.passwordResetFormGroup.disabled).toBe(true);
+    expect(notificationServiceSpy.showError).toHaveBeenCalledWith(
+      'Reset link is invalid or expired',
+      'Error'
+    );
+  });
+
+  it('should show generic error for unexpected reset failures', async () => {
+    await setup();
+    const error = new HttpErrorResponse({
+      status: 500,
+      statusText: 'Server Error',
+    });
+    authServiceSpy.completePasswordReset.and.returnValue(throwError(() => error));
+    component.passwordResetFormGroup.patchValue({
+      newPassword: 'newpassword123',
+      confirmPassword: 'newpassword123',
+    });
+
+    component.onSubmit();
+
+    expect(notificationServiceSpy.showError).toHaveBeenCalledWith(
+      'Something went wrong. please try again',
+      'Error'
+    );
+    expect(console.error).toHaveBeenCalledWith(error);
+  });
+});

--- a/src/app/auth/password-reset/password-reset.component.ts
+++ b/src/app/auth/password-reset/password-reset.component.ts
@@ -1,0 +1,127 @@
+import { NgClass } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, inject, signal } from '@angular/core';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { first } from 'rxjs';
+import CompletePasswordResetDto from '../../models/complete-password-reset-dto';
+import { AuthService } from '../../services/auth.service';
+import { NotificationService } from '../../services/notification.service';
+import { PasswordsEqualValidator } from '../directives/passwords-equal.directive';
+
+@Component({
+  selector: 'app-password-reset',
+  templateUrl: './password-reset.component.html',
+  imports: [NgClass, ReactiveFormsModule],
+})
+export class PasswordResetComponent {
+  private authService = inject(AuthService);
+  private notificationService = inject(NotificationService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+
+  private token = this.route.snapshot.queryParamMap.get('token');
+
+  invalidResetLink = signal(!this.token);
+  waitingForResponse = signal(false);
+  showNewPassword = signal(false);
+  showConfirmPassword = signal(false);
+  passwordResetFormGroup = new FormGroup(
+    {
+      newPassword: new FormControl('', [Validators.required, Validators.minLength(8)]),
+      confirmPassword: new FormControl('', [Validators.required]),
+    },
+    { validators: [PasswordsEqualValidator] }
+  );
+
+  constructor() {
+    if (this.invalidResetLink()) {
+      this.passwordResetFormGroup.disable();
+    }
+  }
+
+  onSubmit() {
+    if (!this.token) {
+      this.invalidResetLink.set(true);
+      this.passwordResetFormGroup.disable();
+      return;
+    }
+
+    this.waitingForResponse.set(true);
+    this.authService
+      .completePasswordReset(this.formGroupToDto(this.token))
+      .pipe(first())
+      .subscribe({
+        next: () => {
+          this.passwordResetFormGroup.reset();
+          this.router
+            .navigate(['/login'])
+            .then(() => this.notificationService.showSuccess('Password has been reset'));
+        },
+        error: (error: HttpErrorResponse) => {
+          this.waitingForResponse.set(false);
+          if (error.status === 400 || error.status === 422) {
+            this.invalidResetLink.set(true);
+            this.passwordResetFormGroup.disable();
+            this.notificationService.showError('Reset link is invalid or expired', 'Error');
+            return;
+          }
+
+          console.error(error);
+          this.notificationService.showError('Something went wrong. please try again', 'Error');
+        },
+      });
+  }
+
+  formGroupToDto(token: string): CompletePasswordResetDto {
+    const values = this.passwordResetFormGroup.value;
+    return {
+      token,
+      newPassword: values.newPassword!,
+      confirmPassword: values.confirmPassword!,
+    };
+  }
+
+  hasErrors(control: AbstractControl | null): boolean {
+    if (!control) return false;
+    return control.invalid && (control.dirty || control.touched);
+  }
+
+  getNewPasswordValidationMessages(): string {
+    if (this.hasErrors(this.newPassword) && this.newPassword?.errors?.['required']) {
+      return 'New password is required';
+    }
+
+    if (this.newPassword?.errors?.['minlength']) {
+      return 'New password must be at least 8 characters long';
+    }
+
+    return '';
+  }
+
+  getConfirmPasswordValidationMessages(): string {
+    if (this.hasErrors(this.confirmPassword) && this.confirmPassword?.errors?.['required']) {
+      return 'Confirm password is required';
+    }
+
+    if (this.passwordResetFormGroup?.errors?.['passwordsEqual']) {
+      return 'Password does not match new password';
+    }
+
+    return '';
+  }
+
+  get newPassword() {
+    return this.passwordResetFormGroup.get('newPassword');
+  }
+
+  get confirmPassword() {
+    return this.passwordResetFormGroup.get('confirmPassword');
+  }
+}

--- a/src/app/dpms/dpm-page/dpm-page.component.ts
+++ b/src/app/dpms/dpm-page/dpm-page.component.ts
@@ -56,6 +56,7 @@ export class DpmPageComponent implements OnInit {
       Validators.pattern(regex24HourTime),
     ]),
     name: new FormControl('', [Validators.required]),
+    driverId: new FormControl<number | null>(null, [Validators.required]),
     block: new FormControl('', [Validators.required, Validators.maxLength(5)]),
     location: new FormControl('', [Validators.required, Validators.maxLength(5)]),
     type: new FormControl(0),

--- a/src/app/dpms/new-dpm/new-dpm.component.html
+++ b/src/app/dpms/new-dpm/new-dpm.component.html
@@ -19,6 +19,7 @@
           [panelClass]="'dpm-form-input border border-neutral-200 rounded-lg shadow-lg mt-1'"
           [suggestions]="autocompleteResults()"
           (completeMethod)="search($event)"
+          (selected)="onDriverSelected($event)"
           [showEmptyMessage]="true"
           [forceSelection]="true"
         ></app-autocomplete>

--- a/src/app/dpms/new-dpm/new-dpm.component.ts
+++ b/src/app/dpms/new-dpm/new-dpm.component.ts
@@ -44,11 +44,22 @@ export class NewDpmComponent {
   }
 
   search(event: AutocompleteCompleteEvent) {
+    if (this.name?.value !== event.query) {
+      this.homeFormGroup().get('driverId')?.setValue(null);
+    }
+
     this.autocompleteResults.set(
       this.driverNames()
         .filter((user) => user.name.toLowerCase().includes(event.query.toLowerCase()))
-        .map((user) => user.name)
+        .map((user) => this.driverLabel(user))
     );
+  }
+
+  onDriverSelected(label: string) {
+    const user = this.driverByLabel(label);
+    this.homeFormGroup()
+      .get('driverId')
+      ?.setValue(user?.id ?? null);
   }
 
   getInputBorderClass(control: AbstractControl | null): string {
@@ -238,7 +249,8 @@ export class NewDpmComponent {
   private formGroupToDto(): PostDpmDto {
     const values = this.homeFormGroup().value;
     const dto: PostDpmDto = {
-      driver: values.name!,
+      driver: this.driverById(values.driverId!)?.name ?? values.name!,
+      driverId: values.driverId!,
       block: values.block!,
       date: this.formatService.dpmDate(values.dpmDate!),
       type: values.type!,
@@ -252,5 +264,21 @@ export class NewDpmComponent {
     }
 
     return dto;
+  }
+
+  private driverLabel(user: UsernameDto): string {
+    return this.hasDuplicateDriverName(user.name) ? `${user.name} (#${user.id})` : user.name;
+  }
+
+  private driverByLabel(label: string): UsernameDto | undefined {
+    return this.driverNames().find((user) => this.driverLabel(user) === label);
+  }
+
+  private driverById(id: number): UsernameDto | undefined {
+    return this.driverNames().find((user) => user.id === id);
+  }
+
+  private hasDuplicateDriverName(name: string): boolean {
+    return this.driverNames().filter((user) => user.name === name).length > 1;
   }
 }

--- a/src/app/models/complete-password-reset-dto.ts
+++ b/src/app/models/complete-password-reset-dto.ts
@@ -1,0 +1,5 @@
+export default interface CompletePasswordResetDto {
+  token: string;
+  newPassword: string;
+  confirmPassword: string;
+}

--- a/src/app/models/create-user-dto.ts
+++ b/src/app/models/create-user-dto.ts
@@ -2,6 +2,7 @@ export default interface CreateUserDto {
   email: string;
   firstname: string;
   lastname: string;
+  managerId: number;
   manager: string;
   role: string;
   fullTime: boolean;

--- a/src/app/models/get-user-detail-dto.ts
+++ b/src/app/models/get-user-detail-dto.ts
@@ -1,5 +1,6 @@
 import UserDetailDto from './user-detail-dto';
+import UsernameDto from './username-dto';
 
 export default interface GetUserDetailDto extends UserDetailDto {
-  managers: string[];
+  managers: UsernameDto[];
 }

--- a/src/app/models/post-dpm-dto.ts
+++ b/src/app/models/post-dpm-dto.ts
@@ -1,5 +1,6 @@
 export default interface PostDpmDto {
   driver: string;
+  driverId: number;
   block: string;
   date: string;
   type: number;

--- a/src/app/models/user-detail-dto.ts
+++ b/src/app/models/user-detail-dto.ts
@@ -3,6 +3,7 @@ export default interface UserDetailDto {
   firstname: string;
   lastname: string;
   points: number;
+  managerId: number | null;
   manager: string;
   role: string;
   fullTime: boolean;

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -225,6 +225,24 @@ describe('AuthService', () => {
     });
   });
 
+  describe('completePasswordReset', () => {
+    it('should send POST request with password reset token DTO', () => {
+      const dto = {
+        token: 'reset-token',
+        newPassword: 'newPassword',
+        confirmPassword: 'newPassword',
+      };
+
+      service.completePasswordReset(dto).subscribe();
+
+      const req = httpMock.expectOne(BASE_URL + '/resetPassword');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(dto);
+
+      req.flush(null);
+    });
+  });
+
   describe('userData initialization', () => {
     it('should load userData from localStorage on construction', () => {
       // Reset TestBed to get fresh instance

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../environments/environment';
 import UserData from '../models/user-data';
 import { NotificationService } from './notification.service';
 import ChangePasswordDto from '../models/change-password-dto';
+import CompletePasswordResetDto from '../models/complete-password-reset-dto';
 
 const BASE_URL = environment.baseUrl + '/auth';
 
@@ -68,6 +69,10 @@ export class AuthService {
 
   changePassword(dto: ChangePasswordDto): Observable<void> {
     return this.http.patch<void>(BASE_URL + '/changePassword', dto);
+  }
+
+  completePasswordReset(dto: CompletePasswordResetDto): Observable<void> {
+    return this.http.post<void>(BASE_URL + '/resetPassword', dto);
   }
 
   private setUserData() {

--- a/src/app/services/dpm.service.spec.ts
+++ b/src/app/services/dpm.service.spec.ts
@@ -137,6 +137,7 @@ describe('DpmService', () => {
     it('should send POST request with DPM data', () => {
       const newDpm = {
         driver: 'John Doe',
+        driverId: 1,
         date: '2024-01-15',
         type: 1,
         block: 'A1',
@@ -157,6 +158,7 @@ describe('DpmService', () => {
     it('should call error service on failure', () => {
       const newDpm = {
         driver: 'John Doe',
+        driverId: 1,
         date: '2024-01-15',
         type: 1,
         block: 'A1',

--- a/src/app/services/user.service.spec.ts
+++ b/src/app/services/user.service.spec.ts
@@ -363,35 +363,35 @@ describe('UserService', () => {
   });
 
   describe('sendPointsBalance', () => {
-    it('should send GET request to email user their points', () => {
+    it('should send POST request to email user their points', () => {
       const userId = '123';
 
       service.sendPointsBalance(userId).subscribe();
 
       const req = httpMock.expectOne(`${BASE_URL}/${userId}/points`);
-      expect(req.request.method).toBe('GET');
+      expect(req.request.method).toBe('POST');
       req.flush(null);
     });
   });
 
   describe('sendPointsBalanceAll', () => {
-    it('should send GET request to email all users their points', () => {
+    it('should send POST request to email all users their points', () => {
       service.sendPointsBalanceAll().subscribe();
 
       const req = httpMock.expectOne(`${BASE_URL}/points`);
-      expect(req.request.method).toBe('GET');
+      expect(req.request.method).toBe('POST');
       req.flush(null);
     });
   });
 
   describe('resetPassword', () => {
-    it('should send GET request to reset user password', () => {
+    it('should send POST request to reset user password', () => {
       const userId = '123';
 
       service.resetPassword(userId).subscribe();
 
       const req = httpMock.expectOne(`${BASE_URL}/${userId}/reset`);
-      expect(req.request.method).toBe('GET');
+      expect(req.request.method).toBe('POST');
       req.flush(null);
     });
 

--- a/src/app/services/user.service.spec.ts
+++ b/src/app/services/user.service.spec.ts
@@ -30,9 +30,13 @@ describe('UserService', () => {
     lastname: 'Doe',
     points: 50,
     role: 'Driver',
+    managerId: 1,
     manager: 'Manager Smith',
     fullTime: true,
-    managers: ['Manager Smith', 'Manager Jones'],
+    managers: [
+      { id: 1, name: 'Manager Smith' },
+      { id: 2, name: 'Manager Jones' },
+    ],
   };
 
   beforeEach(() => {
@@ -199,26 +203,51 @@ describe('UserService', () => {
   });
 
   describe('orderManagers', () => {
-    it('should place current manager first in the list', () => {
-      const managers = ['Alice', 'Bob', 'Charlie'];
-      const result = service.orderManagers('Bob', managers);
+    it('should place selected manager id first when manager names collide', () => {
+      const managers = [
+        { id: 1, name: 'Sam Driver' },
+        { id: 2, name: 'Sam Driver' },
+        { id: 3, name: 'Casey Lead' },
+      ];
 
-      expect(result[0]).toBe('Bob');
+      const result = service.orderManagers(2, managers);
+
+      expect(result[0]).toEqual({ id: 2, name: 'Sam Driver' });
+      expect(result.length).toBe(3);
+    });
+
+    it('should place current manager first in the list', () => {
+      const managers = [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+        { id: 3, name: 'Charlie' },
+      ];
+      const result = service.orderManagers(2, managers);
+
+      expect(result[0]).toEqual({ id: 2, name: 'Bob' });
       expect(result.length).toBe(3);
     });
 
     it('should return original list if current manager not found', () => {
-      const managers = ['Alice', 'Bob', 'Charlie'];
-      const result = service.orderManagers('Unknown', managers);
+      const managers = [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+        { id: 3, name: 'Charlie' },
+      ];
+      const result = service.orderManagers(99, managers);
 
       expect(result).toEqual(managers);
     });
 
     it('should not duplicate the current manager', () => {
-      const managers = ['Alice', 'Bob', 'Charlie'];
-      const result = service.orderManagers('Alice', managers);
+      const managers = [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+        { id: 3, name: 'Charlie' },
+      ];
+      const result = service.orderManagers(1, managers);
 
-      const aliceCount = result.filter((m) => m === 'Alice').length;
+      const aliceCount = result.filter((manager) => manager.id === 1).length;
       expect(aliceCount).toBe(1);
     });
   });
@@ -232,6 +261,7 @@ describe('UserService', () => {
         lastname: 'Updated',
         points: 60,
         role: 'Manager',
+        managerId: 1,
         manager: 'Manager Smith',
         fullTime: true,
       };
@@ -251,6 +281,7 @@ describe('UserService', () => {
         lastname: 'User',
         points: 0,
         role: 'Driver',
+        managerId: 1,
         manager: 'Manager',
         fullTime: true,
       };
@@ -268,8 +299,12 @@ describe('UserService', () => {
   });
 
   describe('getManagers', () => {
-    it('should return list of manager names', () => {
-      const managers = ['Manager A', 'Manager B', 'Manager C'];
+    it('should return list of manager ids and names', () => {
+      const managers = [
+        { id: 1, name: 'Manager A' },
+        { id: 2, name: 'Manager B' },
+        { id: 3, name: 'Manager C' },
+      ];
 
       service.getManagers().subscribe((result) => {
         expect(result).toEqual(managers);
@@ -289,6 +324,7 @@ describe('UserService', () => {
         firstname: 'New',
         lastname: 'User',
         role: 'Driver',
+        managerId: 1,
         manager: 'Manager Smith',
         fullTime: true,
       };
@@ -307,6 +343,7 @@ describe('UserService', () => {
         firstname: 'Test',
         lastname: 'User',
         role: 'Driver',
+        managerId: 1,
         manager: 'Manager Smith',
         fullTime: false,
       };

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -133,7 +133,7 @@ export class UserService {
   }
 
   sendPointsBalance(id: string): Observable<void> {
-    return this.http.get<void>(`${BASE_URL}/${id}/points`).pipe(
+    return this.http.post<void>(`${BASE_URL}/${id}/points`, null).pipe(
       catchError((error: HttpErrorResponse) => {
         return this.errorService.errorResponse(
           error,
@@ -144,7 +144,7 @@ export class UserService {
   }
 
   sendPointsBalanceAll(): Observable<void> {
-    return this.http.get<void>(BASE_URL + '/points').pipe(
+    return this.http.post<void>(BASE_URL + '/points', null).pipe(
       catchError((error: HttpErrorResponse) => {
         return this.errorService.errorResponse(
           error,
@@ -155,7 +155,7 @@ export class UserService {
   }
 
   resetPassword(id: string): Observable<void> {
-    return this.http.get<void>(`${BASE_URL}/${id}/reset`).pipe(
+    return this.http.post<void>(`${BASE_URL}/${id}/reset`, null).pipe(
       catchError((error: HttpErrorResponse) => {
         return this.errorService.errorResponse(
           error,

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -66,14 +66,16 @@ export class UserService {
     return filteredRoles;
   }
 
-  orderManagers(currentManager: string, managers: string[]): string[] {
-    if (!managers.includes(currentManager)) {
-      console.warn(`Failed to find manager '${currentManager}' in manager list`);
+  orderManagers(currentManagerId: number | null, managers: UsernameDto[]): UsernameDto[] {
+    const currentManager = managers.find((manager) => manager.id === currentManagerId);
+
+    if (!currentManager) {
+      console.warn(`Failed to find manager id '${currentManagerId}' in manager list`);
       return managers;
     }
 
     const filteredManagers = [currentManager];
-    filteredManagers.push(...managers.filter((value) => value !== currentManager));
+    filteredManagers.push(...managers.filter((manager) => manager.id !== currentManagerId));
     return filteredManagers;
   }
 
@@ -88,8 +90,8 @@ export class UserService {
     );
   }
 
-  getManagers(): Observable<string[]> {
-    return this.http.get<string[]>(BASE_URL + '/managers').pipe(
+  getManagers(): Observable<UsernameDto[]> {
+    return this.http.get<UsernameDto[]>(BASE_URL + '/managers').pipe(
       catchError((error: HttpErrorResponse) => {
         return this.errorService.errorResponse(
           error,

--- a/src/app/users/user-form/user-form.component.html
+++ b/src/app/users/user-form/user-form.component.html
@@ -97,10 +97,10 @@
       <select
         id="manager-select"
         class="w-full px-4 py-2.5 pr-10 rounded-lg dpm-form-input text-base-content shadow-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 cursor-pointer appearance-none bg-no-repeat bg-[length:1.25rem] bg-[right_0.75rem_center] bg-[url('data:image/svg+xml;charset=UTF-8,%3csvg%20xmlns%3d%22http%3a%2f%2fwww.w3.org%2f2000%2fsvg%22%20viewBox%3d%220%200%2020%2020%22%20fill%3d%22%236b7280%22%3e%3cpath%20fill-rule%3d%22evenodd%22%20d%3d%22M5.293%207.293a1%201%200%20011.414%200L10%2010.586l3.293-3.293a1%201%200%20111.414%201.414l-4%204a1%201%200%2001-1.414%200l-4-4a1%201%200%20010-1.414z%22%20clip-rule%3d%22evenodd%22%2f%3e%3c%2fsvg%3e')]"
-        formControlName="manager"
+        formControlName="managerId"
       >
-        @for (manager of managers; track manager) {
-          <option [value]="manager">{{ manager }}</option>
+        @for (manager of managers ?? []; track manager.id) {
+          <option [ngValue]="manager.id">{{ manager.name }}</option>
         }
       </select>
       <div class="min-h-5"></div>

--- a/src/app/users/user-form/user-form.component.spec.ts
+++ b/src/app/users/user-form/user-form.component.spec.ts
@@ -16,18 +16,23 @@ describe('UserFormComponent', () => {
   let authServiceSpy: jasmine.SpyObj<AuthService>;
   let notificationServiceSpy: jasmine.SpyObj<NotificationService>;
 
+  const mockManagers = [
+    { id: 1, name: 'Manager Smith' },
+    { id: 2, name: 'Manager Jones' },
+    { id: 3, name: 'Manager Wilson' },
+  ];
+
   const mockUserDetail: GetUserDetailDto = {
     email: 'john@example.com',
     firstname: 'John',
     lastname: 'Doe',
     points: 50,
     role: 'Driver',
+    managerId: 1,
     manager: 'Manager Smith',
     fullTime: true,
-    managers: ['Manager Smith', 'Manager Jones'],
+    managers: mockManagers.slice(0, 2),
   };
-
-  const mockManagers = ['Manager Smith', 'Manager Jones', 'Manager Wilson'];
 
   beforeEach(async () => {
     userServiceSpy = jasmine.createSpyObj('UserService', [
@@ -92,7 +97,7 @@ describe('UserFormComponent', () => {
     });
 
     it('should set manager and role defaults', () => {
-      expect(component.userFormGroup.get('manager')?.value).toBe('Manager Smith');
+      expect(component.userFormGroup.get('managerId')?.value).toBe(1);
       expect(component.userFormGroup.get('role')?.value).toBe('Driver');
     });
 
@@ -130,7 +135,7 @@ describe('UserFormComponent', () => {
           email: 'new@example.com',
           firstname: 'New',
           lastname: 'User',
-          manager: 'Manager Smith',
+          managerId: 1,
           role: 'Driver',
           fullTime: true,
         });
@@ -143,6 +148,7 @@ describe('UserFormComponent', () => {
           email: 'new@example.com',
           firstname: 'New',
           lastname: 'User',
+          managerId: 1,
           manager: 'Manager Smith',
           role: 'Driver',
           fullTime: true,
@@ -203,7 +209,7 @@ describe('UserFormComponent', () => {
           email: 'test@example.com',
           firstname: 'Test',
           lastname: 'User',
-          manager: 'Manager Smith',
+          managerId: 1,
           role: 'Driver',
           fullTime: true,
         });
@@ -235,10 +241,7 @@ describe('UserFormComponent', () => {
     });
 
     it('should order managers with user current manager first', () => {
-      expect(userServiceSpy.orderManagers).toHaveBeenCalledWith(
-        'Manager Smith',
-        mockUserDetail.managers
-      );
+      expect(userServiceSpy.orderManagers).toHaveBeenCalledWith(1, mockUserDetail.managers);
     });
 
     it('should populate form with user data', () => {
@@ -313,6 +316,8 @@ describe('UserFormComponent', () => {
             email: 'john@example.com',
             firstname: 'Updated',
             lastname: 'Doe',
+            managerId: 1,
+            manager: 'Manager Smith',
           }),
           '1'
         );

--- a/src/app/users/user-form/user-form.component.ts
+++ b/src/app/users/user-form/user-form.component.ts
@@ -28,6 +28,7 @@ import CreateUserDto from '../../models/create-user-dto';
 import { HttpErrorResponse } from '@angular/common/http';
 import { NgClass } from '@angular/common';
 import { ButtonComponent } from '../../ui/button/button.component';
+import UsernameDto from '../../models/username-dto';
 
 const POINTS_VALIDATORS = [Validators.required, Validators.pattern(/-?\d+/)];
 
@@ -44,7 +45,7 @@ export class UserFormComponent implements OnInit, OnChanges {
   private changeDetector = inject(ChangeDetectorRef);
 
   @Input() @Required layout: 'create' | 'edit' = 'edit';
-  @Input() managers: string[] | null | undefined = undefined;
+  @Input() managers: UsernameDto[] | null | undefined = undefined;
   @Input() userInfo?: { user: GetUserDetailDto; id: string };
   user = signal<GetUserDetailDto | null>(null);
   userId = signal<string | null>(null);
@@ -59,7 +60,7 @@ export class UserFormComponent implements OnInit, OnChanges {
     firstname: new FormControl('', [Validators.required]),
     lastname: new FormControl('', [Validators.required]),
     points: new FormControl(0, POINTS_VALIDATORS),
-    manager: new FormControl(''),
+    managerId: new FormControl<number | null>(null, [Validators.required]),
     role: new FormControl(''),
     fullTime: new FormControl(false, { nonNullable: true }),
   });
@@ -211,7 +212,7 @@ export class UserFormComponent implements OnInit, OnChanges {
       firstname: user.firstname,
       lastname: user.lastname,
       points: user.points,
-      manager: this.managers![0],
+      managerId: this.managers?.[0]?.id ?? user.managerId,
       role: this.roles()[0],
       fullTime: user.fullTime,
     };
@@ -221,9 +222,9 @@ export class UserFormComponent implements OnInit, OnChanges {
   }
 
   private setCreateFormData() {
-    if (this.managers) {
+    if (this.managers?.length) {
       this.userFormGroup.reset({
-        manager: this.managers[0],
+        managerId: this.managers[0].id,
         role: this.roles()[0],
         fullTime: false,
       });
@@ -243,7 +244,8 @@ export class UserFormComponent implements OnInit, OnChanges {
       firstname: values.firstname!,
       lastname: values.lastname!,
       points: values.points!,
-      manager: values.manager!,
+      managerId: values.managerId!,
+      manager: this.managerNameById(values.managerId!),
       role: values.role!,
       fullTime: values.fullTime!,
     };
@@ -255,7 +257,8 @@ export class UserFormComponent implements OnInit, OnChanges {
       email: values.email!,
       firstname: values.firstname!,
       lastname: values.lastname!,
-      manager: values.manager!,
+      managerId: values.managerId!,
+      manager: this.managerNameById(values.managerId!),
       role: values.role!,
       fullTime: values.fullTime!,
     };
@@ -277,7 +280,7 @@ export class UserFormComponent implements OnInit, OnChanges {
     this.user.set(user);
     this.userId.set(this.userInfo.id);
     this.roles.set(this.userService.orderRoles(user.role));
-    this.managers = this.userService.orderManagers(user.manager, user.managers);
+    this.managers = this.userService.orderManagers(user.managerId, user.managers);
 
     if (
       this.authService.userData.username.toLowerCase().trim() === user.email.toLowerCase().trim()
@@ -331,7 +334,7 @@ export class UserFormComponent implements OnInit, OnChanges {
         next: () => {
           this.notificationService.showSuccess('User created');
           this.userFormGroup.reset({
-            manager: this.managers![0],
+            managerId: this.managers?.[0]?.id ?? null,
             role: this.roles()[0],
             fullTime: false,
           });
@@ -354,5 +357,9 @@ export class UserFormComponent implements OnInit, OnChanges {
           }
         },
       });
+  }
+
+  private managerNameById(managerId: number): string {
+    return this.managers?.find((manager) => manager.id === managerId)?.name ?? '';
   }
 }

--- a/src/app/users/users-list/users-list.component.ts
+++ b/src/app/users/users-list/users-list.component.ts
@@ -60,7 +60,7 @@ export class UsersListComponent implements OnInit {
   filteredUsers = signal<UsernameDto[]>([]);
   activeTabName = signal<string>('search');
   isInitialLoad = signal(true);
-  managers = signal<string[] | null>(null);
+  managers = signal<UsernameDto[] | null>(null);
   modalOpen = signal(false);
   modalMessage = signal('');
   outputKey = signal<ListOutputKey>('email');


### PR DESCRIPTION
## Summary

This PR is the frontend companion to the backend audit triage PR in `airfork/uts-dpm`.

Key changes:

- Switch user email/reset side-effect calls to POST endpoints.
- Send stable `driverId` for manual DPM creation.
- Send stable manager IDs for user create/edit forms.
- Add `/passwordReset?token=...` page and API call for tokenized password resets.
- Merge current `origin/main` so the branch is up to date with the latest frontend main.

## Coordinated backend requirement

This PR should be released with backend PR `airfork/uts-dpm#16`.

The new frontend expects the backend API changes from `codex/backend-audit-triage`, including POST user side-effect routes, ID-based write DTOs, and `POST /api/auth/resetPassword`.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test:headless`
- `npm run build`

Result: typecheck/lint/format pass; 770 headless tests pass; build passes with the existing `edit-dpms.component.css` budget warning.

## Manual validation focus

- Login and normal navigation after deployment.
- Create/edit users and confirm manager dropdown saves the intended manager.
- Create a manual DPM and confirm selected driver is correct.
- User detail/list actions:
  - send one user points email
  - send all users points email
  - reset a user password
  - reset part-time point balances
- Password reset email link lands on `/passwordReset?token=...` and successfully sets a new password.
